### PR TITLE
Fix handling of cookie expiration on leap years

### DIFF
--- a/beaker/session.py
+++ b/beaker/session.py
@@ -292,7 +292,7 @@ class Session(dict):
 
     def _delete_cookie(self):
         self.request['set_cookie'] = True
-        expires = datetime.utcnow().replace(year=2003)
+        expires = datetime.utcnow()-datetime.timedelta(365)
         self._set_cookie_values(expires)
         self._update_cookie_out()
 


### PR DESCRIPTION
Fixes 'ValueError: day is out of range for month' when cookie is expired on February 29th (because 2003 wasn't a leap year).

Instead of setting the cookie expiration to 2003, set it to a year ago.
