### PR TITLE
Fix for no dbm systems. Like Windows.

### DIFF
--- a/beaker/container.py
+++ b/beaker/container.py
@@ -2,7 +2,10 @@
 
 import beaker.util as util
 if util.py3k:
-    import dbm as anydbm
+    try:
+        import dbm as anydbm
+    except:
+        import dumbdbm as anydbm
 else:
     import anydbm
 import cPickle


### PR DESCRIPTION
otherwise it will raise exception...

...
  File "C:\Python\env\lib\site-packages\beaker-1.6.3-py3.2.egg\beaker\container.py", line 6, in <module>
    import dbm.ndbm as anydbm
  File "C:\Python32\Lib\dbm\ndbm.py", line 3, in <module>
    from _dbm import *
ImportError: No module named _dbm
