### PR TITLE
Decrease urandom entropy drain

### DIFF
--- a/beaker/session.py
+++ b/beaker/session.py
@@ -252,7 +252,7 @@ class Session(dict):
         """Serialize, encipher, and base64 the session dict"""
         session_data = session_data or self.copy()
         if self.encrypt_key:
-            nonce = b64encode(os.urandom(40))[:8]
+            nonce = b64encode(os.urandom(6))[:8]
             encrypt_key = crypto.generateCryptoKeys(self.encrypt_key,
                                              self.validate_key + nonce, 1)
             data = util.pickle.dumps(session_data, 2)


### PR DESCRIPTION
6 bytes from /dev/urandom should be enough to produce 8 bytes of base-64 data.
In theory entropy should be used only when needed as the entropy pool is a limited resource.

Thanks!
