### PR TITLE
Support whitespaces in namespace

### DIFF
--- a/beaker/ext/memcached.py
+++ b/beaker/ext/memcached.py
@@ -99,7 +99,7 @@ class MemcachedNamespaceManager(NamespaceManager):
                     (self.namespace, key), lock_dir=self.lock_dir)
 
     def _format_key(self, key):
-        formated_key = self.namespace + '_' + key.replace(' ', '\302\267')
+        formated_key = (self.namespace + '_' + (key if isinstance(key, str) else key.decode('ascii'))).replace(' ', '\302\267')
         if len(formated_key) > MAX_KEY_LENGTH:
             formated_key = sha1(formated_key).hexdigest()
         return formated_key


### PR DESCRIPTION
And fix problem with bytes key (encoded in cache.py - Cache._get_value).
