### PR TITLE
Cookie-only session invalidate error.

### DIFF
--- a/beaker/session.py
+++ b/beaker/session.py
@@ -614,7 +614,7 @@ class CookieSession(Session):
 
     def invalidate(self):
         """Clear the contents and start a new session"""
-        self.delete()
+        self.clear()
         self['_id'] = _session_id()
 
 


### PR DESCRIPTION
Hello!

The official docs say:

> If a session should be invalidated, and a new session created and used during the request, the invalidate() method should be used

But when using cookie only session, _invalidate()_ calls _delete()_ method, which sets _expires_ attribute to past. Thus cookie gets deleted by browser, and new session data becomes lost. Here is possible fix and testcase.

Thanks!
