### PR TITLE
Fix for using MySQL cluster memcached as session backend and supporting fail-over within the cluster.

### DIFF
--- a/beaker/session.py
+++ b/beaker/session.py
@@ -263,8 +263,7 @@ class Session(dict):
             data = util.pickle.dumps(session_data, 2)
             return nonce + b64encode(crypto.aesEncrypt(data, encrypt_key))
         else:
-            data = util.pickle.dumps(session_data, 2)
-            return b64encode(data)
+            return util.pickle.dumps(session_data)
 
     def _decrypt_data(self, session_data):
         """Bas64, decipher, then un-serialize the data for the session
@@ -292,8 +291,7 @@ class Session(dict):
                 else:
                     raise
         else:
-            data = b64decode(session_data)
-            return util.pickle.loads(data)
+            return util.pickle.loads(session_data)
 
     def _delete_cookie(self):
         self.request['set_cookie'] = True
@@ -333,7 +331,7 @@ class Session(dict):
             try:
                 session_data = self.namespace['session']
 
-                if (session_data is not None and self.encrypt_key):
+                if (session_data is not None):
                     session_data = self._decrypt_data(session_data)
 
                 # Memcached always returns a key, its None when its not
@@ -411,8 +409,7 @@ class Session(dict):
             else:
                 data = dict(self.items())
 
-            if self.encrypt_key:
-                data = self._encrypt_data(data)
+            data = self._encrypt_data(data)
 
             # Save the data
             if not data and 'session' in self.namespace:

--- a/beaker/session.py
+++ b/beaker/session.py
@@ -263,7 +263,7 @@ class Session(dict):
             data = util.pickle.dumps(session_data, 2)
             return nonce + b64encode(crypto.aesEncrypt(data, encrypt_key))
         else:
-            return util.pickle.dumps(session_data)
+	    return b64encode(util.pickle.dumps(session_data))
 
     def _decrypt_data(self, session_data):
         """Bas64, decipher, then un-serialize the data for the session
@@ -291,7 +291,7 @@ class Session(dict):
                 else:
                     raise
         else:
-            return util.pickle.loads(session_data)
+            return util.pickle.loads(b64decode(session_data))
 
     def _delete_cookie(self):
         self.request['set_cookie'] = True


### PR DESCRIPTION
I was getting very odd "key not found" errors when failing over in a cluster during an active session. The first solution was to remove encryption but that created a new problem of the session storage not being able to rebuild the session data. This update allows for base64 encryption of the pickle object into memcached without an encryption key, allowing the session to be sticky throughout the cluster. I'm open to another solution that allows for encrypting the session.
