### PR TITLE
Made Beaker able to use existing SQLAlchemy Engine

### DIFF
--- a/beaker/cache.py
+++ b/beaker/cache.py
@@ -281,8 +281,13 @@ class Cache(object):
                 raise cls
         except KeyError:
             raise TypeError("Unknown cache implementation %r" % type)
+        self.namespace_args = nsargs
+        if 'database_engine' in self.namespace_args:
+            self.namespace_args['engine'] = self.namespace_args['database_engine']
+            self.namespace_args.pop('database_engine')
+
         self.namespace_name = namespace
-        self.namespace = cls(namespace, **nsargs)
+        self.namespace = cls(namespace, **(self.namespace_args))
         self.expiretime = expiretime or expire
         self.starttime = starttime
         self.nsargs = nsargs

--- a/beaker/ext/database.py
+++ b/beaker/ext/database.py
@@ -34,7 +34,7 @@ class DatabaseNamespaceManager(OpenResourceNamespaceManager):
 
     def __init__(self, namespace, url=None, sa_opts=None, optimistic=False,
                  table_name='beaker_cache', data_dir=None, lock_dir=None,
-                 schema_name=None, **params):
+                 schema_name=None, engine=None, **params):
         """Creates a database namespace manager
 
         ``url``
@@ -52,6 +52,8 @@ class DatabaseNamespaceManager(OpenResourceNamespaceManager):
             The schema name to use in the database for the cache.
         """
         OpenResourceNamespaceManager.__init__(self, namespace)
+
+        self.engine = engine
 
         if sa_opts is None:
             sa_opts = params
@@ -75,7 +77,7 @@ class DatabaseNamespaceManager(OpenResourceNamespaceManager):
                 # SQLAlchemy pops the url, this ensures it sticks around
                 # later
                 sa_opts['sa.url'] = url
-                engine = sa.engine_from_config(sa_opts, 'sa.')
+                engine = self.engine or sa.engine_from_config(sa_opts, 'sa.')
                 meta = sa.MetaData()
                 meta.bind = engine
                 return meta

--- a/beaker/session.py
+++ b/beaker/session.py
@@ -118,6 +118,9 @@ class Session(dict):
         self.namespace_class = namespace_class or clsmap[self.type]
 
         self.namespace_args = namespace_args
+        if 'database_engine' in self.namespace_args:
+            self.namespace_args['engine'] = self.namespace_args['database_engine']
+            self.namespace_args.pop('database_engine')
 
         self.request = request
         self.data_dir = data_dir


### PR DESCRIPTION
Added `beaker.(session|cache).database_engine` configuration option, to pass an exsting SQLAlchemy Engine to the DatabaseNamespaceManager.
Should be used in Runtime and the existing SQLAlchemy Engine added to the configuration.
