### PR TITLE
fix misleading docs regarding SessionMiddleware config

### DIFF
--- a/beaker/middleware.py
+++ b/beaker/middleware.py
@@ -89,9 +89,9 @@ class SessionMiddleware(object):
             dict  All settings should be prefixed by 'session.'. This
             method of passing variables is intended for Paste and other
             setups that accumulate multiple component settings in a
-            single dictionary. If config contains *no cache. prefixed
+            single dictionary. If config contains *no session. prefixed
             args*, then *all* of the config options will be used to
-            intialize the Cache objects.
+            intialize the Session objects.
 
         ``environ_key``
             Location where the Session instance will keyed in the WSGI
@@ -124,8 +124,8 @@ class SessionMiddleware(object):
         # Coerce and validate session params
         coerce_session_params(self.options)
 
-        # Assume all keys are intended for cache if none are prefixed with
-        # 'cache.'
+        # Assume all keys are intended for session if none are prefixed with
+        # 'session.'
         if not self.options and config:
             self.options = config
 


### PR DESCRIPTION
The `SessionMiddleware` docstring and its ctor's code seems to contain copy-pasted code from `CacheMiddleware`, but the references to "cache" are not updated. This can cause much confusion for new users and developers alike, so here's the patch.
