### PR TITLE
Prevented exception.

### DIFF
--- a/beaker/middleware.py
+++ b/beaker/middleware.py
@@ -151,7 +151,7 @@ class SessionMiddleware(object):
                     cookie = session.__dict__['_headers']['cookie_out']
                     if cookie:
                         headers.append(('Set-cookie', cookie))
-            return start_response(status, headers, exc_info)
+            return start_response(status, headers)
         return self.wrap_app(environ, session_start_response)
 
     def _get_session(self):


### PR DESCRIPTION
Not sure if this is a good thing, but it prevented the following error from happening when I close a geventwebsocket connection. Anyone have any other information?

```
<h1>Critical error while processing request: /control</h1>Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/gevent/pywsgi.py", line 508, in handle_one_response
    self.run_application()
  File "/usr/local/lib/python2.7/dist-packages/geventwebsocket/handler.py", line 72, in run_application
    self.run_websocket()
  File "/usr/local/lib/python2.7/dist-packages/geventwebsocket/handler.py", line 52, in run_websocket
    self.application(self.environ, lambda s, h: [])
  File "/usr/local/lib/python2.7/dist-packages/beaker/middleware.py", line 155, in __call__
    return self.wrap_app(environ, session_start_response)
  File "/usr/local/lib/python2.7/dist-packages/bottle.py", line 874, in __call__
    return self.wsgi(environ, start_response)
  File "/usr/local/lib/python2.7/dist-packages/bottle.py", line 869, in wsgi
    start_response('500 INTERNAL SERVER ERROR', headers)
  File "/usr/local/lib/python2.7/dist-packages/beaker/middleware.py", line 154, in session_start_response
    return start_response(status, headers, exc_info)
TypeError: <lambda>() takes exactly 2 arguments (3 given)
```