### PR TITLE
Support of kwargs in cache decorators. Resolves bbangert/beaker#62

### DIFF
--- a/beaker/cache.py
+++ b/beaker/cache.py
@@ -6,6 +6,7 @@ as well as the function decorators :func:`.region_decorate`,
 :func:`.region_invalidate`.
 
 """
+from functools import wraps
 import warnings
 
 import beaker.container as container
@@ -533,6 +534,7 @@ def _cache_decorate(deco_args, manager, deco_kwargs, region):
         namespace = util.func_namespace(func)
         skip_self = util.has_self_arg(func)
 
+        @wraps(func)
         def cached(*args, **kwargs):
             if not cache[0]:
                 if region is not None:

--- a/beaker/cache.py
+++ b/beaker/cache.py
@@ -524,7 +524,7 @@ class CacheManager(object):
         _cache_decorator_invalidate(cache, key_length, args)
 
 
-def _cache_decorate(deco_args, manager, kwargs, region):
+def _cache_decorate(deco_args, manager, deco_kwargs, region):
     """Return a caching function decorator."""
 
     cache = [None]
@@ -533,7 +533,7 @@ def _cache_decorate(deco_args, manager, kwargs, region):
         namespace = util.func_namespace(func)
         skip_self = util.has_self_arg(func)
 
-        def cached(*args):
+        def cached(*args, **kwargs):
             if not cache[0]:
                 if region is not None:
                     if region not in cache_regions:
@@ -541,35 +541,40 @@ def _cache_decorate(deco_args, manager, kwargs, region):
                             'Cache region not configured: %s' % region)
                     reg = cache_regions[region]
                     if not reg.get('enabled', True):
-                        return func(*args)
+                        return func(*args, **kwargs)
                     cache[0] = Cache._get_cache(namespace, reg)
                 elif manager:
-                    cache[0] = manager.get_cache(namespace, **kwargs)
+                    cache[0] = manager.get_cache(namespace, **deco_kwargs)
                 else:
                     raise Exception("'manager + kwargs' or 'region' "
                                     "argument is required")
 
             if skip_self:
                 try:
-                    cache_key = " ".join(map(str, deco_args + args[1:]))
+                    joined_kwargs = " ".join(['{0}:{1}'.format(key, value) for key, value in kwargs.items()])
+                    cache_key = " ".join(map(str, deco_args + args[1:])) + joined_kwargs
                 except UnicodeEncodeError:
-                    cache_key = " ".join(map(unicode, deco_args + args[1:]))
+                    joined_kwargs = " ".join([u'{0}:{1}'.format(key, value) for key, value in kwargs.items()])
+                    cache_key = " ".join(map(unicode, deco_args + args[1:])) + joined_kwargs
+
             else:
                 try:
-                    cache_key = " ".join(map(str, deco_args + args))
+                    joined_kwargs = " ".join(['{0}:{1}'.format(key, value) for key, value in kwargs.items()])
+                    cache_key = " ".join(map(str, deco_args + args)) + joined_kwargs
                 except UnicodeEncodeError:
-                    cache_key = " ".join(map(unicode, deco_args + args))
+                    joined_kwargs = " ".join([u'{0}:{1}'.format(key, value) for key, value in kwargs.items()])
+                    cache_key = " ".join(map(unicode, deco_args + args)) + joined_kwargs
             if region:
                 key_length = cache_regions[region]['key_length']
             else:
-                key_length = kwargs.pop('key_length', 250)
+                key_length = deco_kwargs.pop('key_length', 250)
             if len(cache_key) + len(namespace) > int(key_length):
                 if util.py3k:
                     cache_key = cache_key.encode('utf-8')
                 cache_key = sha1(cache_key).hexdigest()
 
             def go():
-                return func(*args)
+                return func(*args, **kwargs)
 
             return cache[0].get_value(cache_key, createfunc=go)
         cached._arg_namespace = namespace

--- a/tests/test_cache_decorator.py
+++ b/tests/test_cache_decorator.py
@@ -24,6 +24,11 @@ def alfred(x, xx, y=None):
     return time.time()
 
 @cache_region('short_term')
+def albert(x):
+    """A doc string"""
+    return time.time()
+
+@cache_region('short_term')
 def alfred_self(self, xx, y=None):
     return time.time()
 
@@ -244,3 +249,13 @@ def test_check_region_decorator_with_kwargs_and_self():
 
     result3 = alfred_self('fake_self2', 5, y=5)
     assert result != result3
+
+
+def test_check_region_decorator_keeps_docstring_and_name():
+    result = albert(1)
+    time.sleep(1)
+    result2 = albert(1)
+    assert result == result2
+
+    assert albert.__doc__ == "A doc string"
+    assert albert.__name__ == "albert"

--- a/tests/test_cache_decorator.py
+++ b/tests/test_cache_decorator.py
@@ -19,6 +19,14 @@ def fred(x):
 def george(x):
     return time.time()
 
+@cache_region('short_term')
+def alfred(x, xx, y=None):
+    return time.time()
+
+@cache_region('short_term')
+def alfred_self(self, xx, y=None):
+    return time.time()
+
 def make_cache_obj(**kwargs):
     opts = defaults.copy()
     opts.update(kwargs)
@@ -216,3 +224,23 @@ def test_class_key_region_invalidate():
 
     assert x == y
     assert x != z
+
+
+def test_check_region_decorator_with_kwargs():
+    result = alfred(1, xx=5, y=3)
+    time.sleep(1)
+    result2 = alfred(1, y=3, xx=5)
+    assert result == result2
+
+    result3 = alfred(1, 5, y=5)
+    assert result != result3
+
+
+def test_check_region_decorator_with_kwargs_and_self():
+    result = alfred_self('fake_self', xx=5, y='blah')
+    time.sleep(1)
+    result2 = alfred_self('fake_self2', y='blah', xx=5)
+    assert result == result2
+
+    result3 = alfred_self('fake_self2', 5, y=5)
+    assert result != result3


### PR DESCRIPTION
Cache decorators now take into account args and kwargs of a decorated function.
Cache key is now generated regarding these 2 properties.