### PR TITLE
Updated deserialize function to use method parameter first

### DIFF
--- a/beaker/util.py
+++ b/beaker/util.py
@@ -470,10 +470,7 @@ def serialize(data, method):
         return pickle.dumps(data, 2)
 
 def deserialize(data_string, method):
-    try:
+    if method == 'json':
+        return json.loads(data_string.decode('zlib'))
+    else:
         return pickle.loads(data_string)
-    except pickle.PickleError:
-        try:
-            return json.loads(data_string.decode('zlib'))
-        except:
-            raise


### PR DESCRIPTION
Previous patch was not using the method parameter in the deserialize function and instead attempting to depickle first, then if that failed fallback to json.  This means the security issue was not fixed, as pickle was still being called.