### PR TITLE
Fixed cookie path setting

### DIFF
--- a/beaker/session.py
+++ b/beaker/session.py
@@ -507,7 +507,7 @@ class CookieSession(Session):
         self.secure = secure
         self.httponly = httponly
         self._domain = cookie_domain
-        self._path = cookie_path
+        self.path = cookie_path
 
         try:
             cookieheader = request['cookie']


### PR DESCRIPTION
The cookie path option which is given to the session as a session option
was always reset to "/", due to it being set from the internal property
dictionary. This was fixed by using the proper accessor in the
constructor.
