### PR TITLE
added __enter__and __exit__ to proxy to underlying apps that may...

### DIFF
--- a/beaker/middleware.py
+++ b/beaker/middleware.py
@@ -154,6 +154,13 @@ class SessionMiddleware(object):
             return start_response(status, headers, exc_info)
         return self.wrap_app(environ, session_start_response)
 
+    def __enter__(self):
+        self.app.__enter__()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.app.__exit__(exc_type, exc_value, traceback)
+        
     def _get_session(self):
         return Session({}, use_cookies=False, **self.options)
 


### PR DESCRIPTION
added __enter__and __exit__ to proxy to underlying apps that may make use of these utilities (via 'with' statement, e.g.)  For example, in bottle you can say:

    app = Bottle()
    with app:
        @get('/home')
       def home():
           ...

(Instead of @app.get(...), for example.)  But when the app is wrapped using 

    app = SessionMiddleware(app, config)

then you cannot use the 'with app' construct.  This submission fixes that.
