### PR TITLE
Clarify wsgi_app object purpose in example

### DIFF
--- a/beaker/docs/sessions.rst
+++ b/beaker/docs/sessions.rst
@@ -66,6 +66,9 @@ Complete example using a basic WSGI app with sessions::
     }
     wsgi_app = SessionMiddleware(simple_app, session_opts)
 
+Now ``wsgi_app`` is a replacement of original application ``simple_app``.
+You should specify it as a request handler in your WSGI configuration file.
+
 .. note::
     This example does **not** actually save the session for the next request.
     Adding the :meth:`~beaker.session.Session.save` call explained below is


### PR DESCRIPTION
I've spent a while trying to undestand why sessions example does not work out-of-the-box. After googling "KeyError beaker.session" I've found the discussion https://groups.google.com/forum/#!topic/modwsgi/lyRhHIr48nk where people pointed out to this misleading inaccuracy. We should explain to newcomer that old handler ``simple_app`` is overrided by new one created by Beaker's Middleware.