### PR TITLE
share instances of pylibmc.ThreadMappedPool in PyLibMCNamespaceManager

### DIFF
--- a/tests/test_memcached.py
+++ b/tests/test_memcached.py
@@ -332,4 +332,19 @@ class TestPylibmcInit(unittest.TestCase):
             assert mc.behaviors["tcp_nodelay"] == 1
             assert "auto_eject" in mc.behaviors
             assert mc.behaviors["auto_eject"] == 0
-            
+
+    def test_pylibmc_pool_sharing(self):
+        from beaker.ext import memcached
+        cache_1a = Cache('test_1a', data_dir='./cache',
+                            memcache_module='pylibmc',
+                            url=mc_url, type="ext:memcached")
+        cache_1b = Cache('test_1b', data_dir='./cache',
+                            memcache_module='pylibmc',
+                            url=mc_url, type="ext:memcached")
+        cache_2 = Cache('test_2', data_dir='./cache',
+                            memcache_module='pylibmc',
+                            url='127.0.0.1:11212', type="ext:memcached")
+
+        assert (cache_1a.namespace.pool is cache_1b.namespace.pool)
+        assert (cache_1a.namespace.pool is not cache_2.namespace.pool)
+


### PR DESCRIPTION
When using pylibmc as the memcache_module, each namespace gets its own instance of ThreadMappedPool. This causes a separate connection to the same memcached url for every namespace. This change makes sure that pools are shared between different namespaces the same way that clients are shared, and reduces the number of open connections when using pylibmc with multiple namespaces.