### PR TITLE
Add save_accessed_time option

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,9 +2,10 @@ Release $next
 =============
 
 * Sessions have a new option save_accessed_time which defaults to true for
-  backwards compatibility. Set to false to tell beaker not to add _accessed_time
-  to the session and the last_accessed attribute. This lets you avoid session
-  writes for requests that don't otherwise update the session.
+  backwards compatibility. Set to false to tell beaker not to update
+  _accessed_time if the session hasn't been changed, for non-cookie sessions
+  stores. This lets you avoid needless datastore writes. _accessed_time will
+  always be updated when the session is intentionally saved.
 
 Release 1.8.0 (2016-01-26)
 ==========================

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,11 @@
+Release $next
+=============
+
+* Sessions have a new option save_accessed_time which defaults to true for
+  backwards compatibility. Set to false to tell beaker not to add _accessed_time
+  to the session and the last_accessed attribute. This lets you avoid session
+  writes for requests that don't otherwise update the session.
+
 Release 1.8.0 (2016-01-26)
 ==========================
 

--- a/beaker/docs/configuration.rst
+++ b/beaker/docs/configuration.rst
@@ -170,6 +170,12 @@ cookie_domain (**optional**, string)
 key (**required**, string)
     Name of the cookie key used to save the session under.
 
+save_accessed_time (**optional**, bool)
+    Whether beaker should save the session's access time (true) or only
+    modification time (false).
+
+    Defaults to true.
+
 secret (**required**, string)
     Used with the HMAC to ensure session integrity. This value should
     ideally be a randomly generated string.
@@ -188,6 +194,8 @@ timeout (**optional**, integer)
     the session was last accessed, not from when the session was created.
 
     Defaults to never expiring.
+
+    Requires that save_accessed_time be true.
 
 
 Encryption Options

--- a/beaker/docs/sessions.rst
+++ b/beaker/docs/sessions.rst
@@ -84,11 +84,13 @@ application.
 
 * id - Unique 40 char SHA-generated session ID
 * last_accessed - The last time the session was accessed before the current
-  access, will be None if the session was just made
+  access, will be None if the session was just made; only set if the
+  save_accessed_time setting is true (the default)
 
 There's several special session keys populated as well:
 
-* _accessed_time - Current accessed time of the session, when it was loaded
+* _accessed_time - Current accessed time of the session, when it was loaded;
+  only set if the save_accessed_time setting is true (the default)
 * _creation_time - When the session was created
 
 

--- a/beaker/docs/sessions.rst
+++ b/beaker/docs/sessions.rst
@@ -84,13 +84,13 @@ application.
 
 * id - Unique 40 char SHA-generated session ID
 * last_accessed - The last time the session was accessed before the current
-  access, will be None if the session was just made; only set if the
-  save_accessed_time setting is true (the default)
+  access, if save_accessed_time is true; the last time it was modified if false;
+  will be None if the session was just made
 
 There's several special session keys populated as well:
 
-* _accessed_time - Current accessed time of the session, when it was loaded;
-  only set if the save_accessed_time setting is true (the default)
+* _accessed_time - When the session was loaded if save_accessed_time is true;
+  when it was last written if false
 * _creation_time - When the session was created
 
 

--- a/beaker/middleware.py
+++ b/beaker/middleware.py
@@ -106,8 +106,9 @@ class SessionMiddleware(object):
 
         # Load up the default params
         self.options = dict(invalidate_corrupt=True, type=None,
-                           data_dir=None, key='beaker.session.id',
-                           timeout=None, secret=None, log_file=None)
+                            data_dir=None, key='beaker.session.id',
+                            timeout=None, save_accessed_time=True, secret=None,
+                            log_file=None)
 
         # Pull out any config args meant for beaker session. if there are any
         for dct in [config, kwargs]:

--- a/beaker/util.py
+++ b/beaker/util.py
@@ -304,6 +304,8 @@ def coerce_session_params(params):
         ('secure', (bool, NoneType), "Session secure must be a boolean."),
         ('httponly', (bool, NoneType), "Session httponly must be a boolean."),
         ('timeout', (int, NoneType), "Session timeout must be an integer."),
+        ('save_accessed_time', (bool, NoneType),
+         "Session save_accessed_time must be a boolean (defaults to true)."),
         ('auto', (bool, NoneType), "Session is created if accessed."),
         ('webtest_varname', (str, NoneType), "Session varname must be a string."),
         ('data_serializer', (str,), "data_serializer must be a string.")
@@ -313,6 +315,8 @@ def coerce_session_params(params):
     if cookie_expires and isinstance(cookie_expires, int) and \
        not isinstance(cookie_expires, bool):
         opts['cookie_expires'] = timedelta(seconds=cookie_expires)
+    if opts['timeout'] is not None and not ops['save_accessed_time']:
+        raise Exception("save_accessed_time must be true to use timeout")
     return opts
 
 

--- a/beaker/util.py
+++ b/beaker/util.py
@@ -315,7 +315,7 @@ def coerce_session_params(params):
     if cookie_expires and isinstance(cookie_expires, int) and \
        not isinstance(cookie_expires, bool):
         opts['cookie_expires'] = timedelta(seconds=cookie_expires)
-    if opts['timeout'] is not None and not ops['save_accessed_time']:
+    if opts['timeout'] is not None and not opts['save_accessed_time']:
         raise Exception("save_accessed_time must be true to use timeout")
     return opts
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -367,7 +367,10 @@ class TestSaveAccessedTime(unittest.TestCase):
         session = get_session(data_dir='./cache', save_accessed_time=False,
                               id=session.id)
         # If the second save saved, we'll have a new last_accessed time.
-        self.assertGreater(session.last_accessed, last_accessed)
+        # Python 2.6 doesn't have assertGreater :-(
+        assert session.last_accessed > last_accessed, (
+            '%r is not greater than %r' %
+            (session.last_accessed, last_accessed))
 
 
     def test_saves_if_session_not_written_and_accessed_time_true(self):
@@ -382,7 +385,10 @@ class TestSaveAccessedTime(unittest.TestCase):
         session = get_session(data_dir='./cache', save_accessed_time=True,
                               id=session.id)
         # If the second save saved, we'll have a new last_accessed time.
-        self.assertGreater(session.last_accessed, last_accessed)
+        # Python 2.6 doesn't have assertGreater :-(
+        assert session.last_accessed > last_accessed, (
+            '%r is not greater than %r' %
+            (session.last_accessed, last_accessed))
 
 
     def test_doesnt_save_if_session_not_written_and_accessed_time_false(self):

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -194,10 +194,11 @@ def test_timeout():
 
 
 def test_timeout_requires_accessed_time():
-    """Test that it doesn't allow setting save_accessed_time to True with
+    """Test that it doesn't allow setting save_accessed_time to False with
     timeout enabled
     """
     get_session(timeout=None, save_accessed_time=True)  # is ok
+    get_session(timeout=None, save_accessed_time=False)  # is ok
     assert_raises(BeakerException,
                   get_session,
                   timeout=2,


### PR DESCRIPTION
On sites that aren't using `session[_accessed_time]` or `session.last_accessed`, saving the session at the end of every request is wasted work. On big sites this can become a fair amount of load on a data store.

This adds an option to turn off access time storage, in which case if there aren't other changes to the session, it doesn't need to be written at all. It defaults to saving access times for backwards compatibility.