### PR TITLE
fix to import StringIO.StringIO first

### DIFF
--- a/beaker/cache.py
+++ b/beaker/cache.py
@@ -99,9 +99,9 @@ class _backends(object):
                     if not isinstance(sys.exc_info()[1], DistributionNotFound):
                         import traceback
                         try:
-                            from io import StringIO
+                            from StringIO import StringIO  # Python2
                         except ImportError:
-                            from StringIO import StringIO
+                            from io import StringIO        # Python3
 
                         tb = StringIO()
                         traceback.print_exc(file=tb)


### PR DESCRIPTION
In Python 2.6 and 2.7, `io.StringIO` class is available but it is not compatible
with `String.StringIO` class.

* `io.StringIO` class accepts unicode string.
* `StringIO.StringIO` class accepts bytes string.

Therefore `StringIO.StringIO` class should be imported prior to `io.StringIO`.
Otherwise, `traceback.print_exc(file=tb)` (line 107) will raise TypeError.
For example:

```
  File "/opt/python/blue_env/local/lib/python2.7/site-packages/Beaker-1.8.0-py2.7.egg/beaker/cache.py", line 107, in _init
    traceback.print_exc(file=tb)
  File "/usr/lib/python2.7/traceback.py", line 241, in print_exc
    print_exception(etype, value, tb, limit, file)
  File "/usr/lib/python2.7/traceback.py", line 132, in print_exception
    _print(file, 'Traceback (most recent call last):')
  File "/usr/lib/python2.7/traceback.py", line 15, in _print
    file.write(str+terminator)
TypeError: unicode argument expected, got 'str'
```