### PR TITLE
Allow using pycryptodome, and prefer it over pycrypto

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ if not hasattr(inspect, 'signature'):
     INSTALL_REQUIRES.append('funcsigs')
 
 
-TESTS_REQUIRE = ['nose', 'webtest', 'Mock', 'pycrypto', 'cryptography']
+TESTS_REQUIRE = ['nose', 'webtest', 'Mock', 'pycryptodome', 'cryptography']
 
 if py_version == (3, 2):
     TESTS_REQUIRE.append('coverage < 4.0')
@@ -69,6 +69,7 @@ setup(name='Beaker',
       extras_require={
           'crypto': ['pycryptopp>=0.5.12'],
           'pycrypto': ['pycrypto'],
+          'pycryptodome': ['pycryptodome'],
           'cryptography': ['cryptography'],
           'testsuite': [TESTS_REQUIRE]
       },


### PR DESCRIPTION
pycryptodome is a maintained fork of pycrypto. They are mostly
API-compatible (and use the same package name, i.e. meant to be
a drop-in replacement), and AFAICS the little bit of API that Beaker
uses is fully compatible.

Therefore, list pycryptodome as another extra dependency. Furthermore,
since pycrypto is dead and being phased out whenever possible, use
pycryptodome for tests instead of it.