### PR TITLE
Fix docs building and document Redis/MongoDB

### DIFF
--- a/beaker/docs/conf.py
+++ b/beaker/docs/conf.py
@@ -130,21 +130,6 @@ html_static_path = ['_static']
 # html_additional_pages = {'index': 'index.html'}
 
 html_theme_options = {
-    "bgcolor": "#fff",
-    "footertextcolor": "#666",
-    "relbarbgcolor": "#fff",
-    "relbarlinkcolor": "#590915",
-    "relbartextcolor": "#FFAA2D",
-    "sidebarlinkcolor": "#590915",
-    "sidebarbgcolor": "#fff",
-    "sidebartextcolor": "#333",
-    "footerbgcolor": "#fff",
-    "linkcolor": "#590915",
-    "bodyfont": "helvetica, 'bitstream vera sans', sans-serif",
-    "headfont": "georgia, 'bitstream vera sans serif', 'lucida grande', helvetica, verdana, sans-serif",
-    "headbgcolor": "#fff",
-    "headtextcolor": "#12347A",
-    "codebgcolor": "#fff",
 }
 
 # If false, no module index is generated.

--- a/beaker/docs/configuration.rst
+++ b/beaker/docs/configuration.rst
@@ -97,7 +97,8 @@ type (**required**, string)
     The name of the back-end to use for storing the sessions or cache objects.
 
     Available back-ends supplied with Beaker: ``file``, ``dbm``, ``memory``,
-    ``ext:memcached``, ``ext:database``, ``ext:google``
+    ``ext:memcached``, ``ext:database``, ``ext:google``, ``ext:mongodb``,
+    and ``ext:redis``.
 
     For sessions, the additional type of ``cookie`` is available which
     will store all the session data in the cookie itself. As such, size
@@ -110,11 +111,11 @@ webtest_varname (**optional**, string)
     the environ for use with WebTest. The name provided here is where the
     session object will be attached to the WebTest TestApp return value.
 
-url (**optional**, string)
-    URL is specific to use of either ext:memcached or ext:database. When using
-    one of those types, this option is **required**.
+url (**optional**, string) URL is specific to use of either ``ext:memcached``,
+    ``ext:database``, ``ext:mongodb``, or ``ext:redis``. When using one of those
+    types, this option is **required**.
 
-    When used with ext:memcached, this should be either a single, or
+    When used with ``ext:memcached``, this should be either a single, or
     semi-colon separated list of memcached servers::
 
         session_opts = {
@@ -122,8 +123,11 @@ url (**optional**, string)
             'session.url': '127.0.0.1:11211',
         }
 
-    When used with ext:database, this should be a valid `SQLAlchemy`_ database
+    When used with ``ext:database``, this should be a valid `SQLAlchemy`_ database
     string.
+
+    When used with ``ext:redis``, this should be an URL as passed to
+    ``StrictRedis.from_url()``.
 
 
 Session Options
@@ -220,9 +224,9 @@ crypto_type (**optional**, string)
 
 .. note::
 
-	You may need to install additional libraries to use Beaker's
-	cookie-based session encryption. See the :ref:`encryption` section for
-	more information.
+  You may need to install additional libraries to use Beaker's
+  cookie-based session encryption. See the :ref:`encryption` section for
+  more information.
 
 Cache Options
 =============

--- a/beaker/docs/index.rst
+++ b/beaker/docs/index.rst
@@ -8,7 +8,7 @@ ease of use with any Python based application.
 
 * **Lazy-Loading Sessions**: No performance hit for having sessions active in a request unless they're actually used
 * **Performance**: Utilizes a multiple-reader / single-writer locking system to prevent the Dog Pile effect when caching.
-* **Multiple Back-ends**: File-based, DBM files, memcached, memory, and database (via SQLAlchemy) back-ends available for sessions and caching
+* **Multiple Back-ends**: File-based, DBM files, memcached, memory, Redis, MongoDB, and database (via SQLAlchemy) back-ends available for sessions and caching
 * **Cookie-based Sessions**: SHA-1 signatures with optional AES encryption for client-side cookie-based session storage
 * **Flexible Caching**: Data can be cached per function to different back-ends, with different expirations, and different keys
 * **Extensible Back-ends**: Add more back-ends using setuptools entrypoints to support new back-ends.
@@ -53,4 +53,3 @@ Module Listing
     modules/google
     modules/sqla
     modules/pbkdf2
-

--- a/beaker/session.py
+++ b/beaker/session.py
@@ -801,6 +801,7 @@ class SessionObject(object):
 
         Always saves the whole session if save() or delete() have been called.
         If they haven't:
+
         - If autosave is set to true, saves the the entire session regardless.
         - If save_accessed_time is set to true or unset, only saves the updated
           access time.


### PR DESCRIPTION
The conf.py contained theme settings that broke the build with lates Sphinx and
that are also not relevant to the now used RTD theme.

Mention Redis and MongoDB as available backends since I've missed them myself
when looking at the docs.

Fix markup in one docstring that generated an RST error.