### PR TITLE
Support modifying session's  cookie_expires attribute on runtime.

### DIFF
--- a/beaker/session.py
+++ b/beaker/session.py
@@ -158,7 +158,7 @@ class Session(dict):
         self.timeout = timeout
         self.save_atime = save_accessed_time
         self.use_cookies = use_cookies
-        self.cookie_expires = cookie_expires
+        self._cookie_expires = cookie_expires
 
         self._set_serializer(data_serializer)
 
@@ -244,7 +244,7 @@ class Session(dict):
 
     def _set_cookie_expires(self, expires):
         if expires is None:
-            expires = self.cookie_expires
+            expires = self._cookie_expires
         if expires is False:
             expires_date = datetime.fromtimestamp(0x7FFFFFFF)
         elif isinstance(expires, timedelta):
@@ -253,8 +253,8 @@ class Session(dict):
             expires_date = expires
         elif expires is not True:
             raise ValueError("Invalid argument for cookie_expires: %s"
-                             % repr(self.cookie_expires))
-        self.cookie_expires = expires
+                             % repr(self._cookie_expires))
+        self._cookie_expires = expires
         if not self.cookie or self.key not in self.cookie:
             self.cookie[self.key] = self.id
         if expires is True:
@@ -264,8 +264,8 @@ class Session(dict):
             expires_date.strftime("%a, %d-%b-%Y %H:%M:%S GMT")
         return expires_date
 
-    def _update_cookie_out(self, set_cookie=True):
-        self._set_cookie_values()
+    def _update_cookie_out(self, set_cookie=True, cookie_expires=None):
+        self._set_cookie_values(expires=cookie_expires)
         self.request['cookie_out'] = self.cookie[self.key].output(header='')
         self.request['set_cookie'] = set_cookie
 
@@ -291,6 +291,17 @@ class Session(dict):
     @property
     def created(self):
         return self['_creation_time']
+
+    def _set_cookie_expires_wrapper(self, cookie_expires):
+        if cookie_expires and isinstance(cookie_expires, int) and \
+                not isinstance(cookie_expires, bool):
+            cookie_expires = timedelta(seconds=cookie_expires)
+        self._update_cookie_out(cookie_expires=cookie_expires)
+
+    def _get_cookie_expires(self):
+        return self._cookie_expires
+
+    cookie_expires = property(_get_cookie_expires, _set_cookie_expires_wrapper)
 
     def _set_domain(self, domain):
         self['_domain'] = self._domain = domain
@@ -566,7 +577,7 @@ class CookieSession(Session):
         self.key = key
         self.timeout = timeout
         self.save_atime = save_accessed_time
-        self.cookie_expires = cookie_expires
+        self._cookie_expires = cookie_expires
         self.encrypt_key = encrypt_key
         self.validate_key = validate_key
         self.encrypt_nonce_size = get_nonce_size(encrypt_nonce_bits)


### PR DESCRIPTION
With this feature, we call easy expire session due to inactivity of a user.

For example, if we want to expire the cookie when the browser has not requested any page in 5 minutes, we can do this:

```python
# Flask
@app.after_request
def per_request_callbacks(response):
    session = request.environ['beaker.session']
    session.cookie_expires = 300
    return response
```
