### PR TITLE
buffer pickle into string before writing to file to prevent corruption

### DIFF
--- a/beaker/container.py
+++ b/beaker/container.py
@@ -677,7 +677,8 @@ class FileNamespaceManager(OpenResourceNamespaceManager):
     def do_close(self):
         if self.flags == 'c' or self.flags == 'w':
             fh = open(self.file, 'wb')
-            pickle.dump(self.hash, fh)
+            pickledata = pickle.dumps(self.hash)
+            fh.write(pickledata)
             fh.close()
 
         self.hash = {}


### PR DESCRIPTION
For an application I maintain I noticed a high level of corrupted pickles taking place, which in turn results not only in a missed cache but also an EOFile error that can not be caught by the cache decorator.

This is caused by the program closing before finishing the pickle and file writing operations. When this occurs a partially written file exists, which later can not be deserialized.

For the corruption to occur the process has to end while the file is being written but before it is finished. In general this should be very difficult to occur, but because the pickler itself starts writing immediately rather than using a buffer- so the entire time that pickling occurs this bug could present itself.

This PR buffers the pickle output into a string before flushing it to the filesystem. This reduces the amount of time that the file is being written to considerably as all the output is flushed in one call. In turn this prevents the corruption from occurring as often.