### PR TITLE
On posix systems write to tmp file before moving into place

### DIFF
--- a/beaker/container.py
+++ b/beaker/container.py
@@ -676,9 +676,16 @@ class FileNamespaceManager(OpenResourceNamespaceManager):
 
     def do_close(self):
         if self.flags == 'c' or self.flags == 'w':
-            fh = open(self.file, 'wb')
-            pickle.dump(self.hash, fh)
-            fh.close()
+            if os.name == 'posix':
+                tempname = '%s.temp' % (self.file)
+                fh = open(tempname, 'wb')
+                pickle.dump(self.hash, fh)
+                fh.close()
+                os.rename(tempname, self.file)
+            else:
+                fh = open(self.file, 'wb')
+                pickle.dump(self.hash, fh)
+                fh.close()
 
         self.hash = {}
         self.flags = None


### PR DESCRIPTION
If a process is interrupted while saving cached data it could end up saving a partial file. This results in an exception being thrown later due to the corrupted cache.

This PR fixes this by saving the data to a temporary file and moving it into place once writing has completed. On posix systems the `rename` operation is atomic, so the system will either successfully move the file or fail- there will be no corruption.

Unfortunately the rename operations are not atomic on Windows, so this PR explicitly checks for a posix system or it will fall back on the previous behavior.