### PR TITLE
create new `safe_write` function, buffer pickling on all platforms

### DIFF
--- a/beaker/container.py
+++ b/beaker/container.py
@@ -683,8 +683,9 @@ class FileNamespaceManager(OpenResourceNamespaceManager):
                 fh.close()
                 os.rename(tempname, self.file)
             else:
+                pickled = pickle.dumps(self.hash)
                 fh = open(self.file, 'wb')
-                pickle.dump(self.hash, fh)
+                fh.write(pickled)
                 fh.close()
 
         self.hash = {}

--- a/beaker/container.py
+++ b/beaker/container.py
@@ -676,17 +676,8 @@ class FileNamespaceManager(OpenResourceNamespaceManager):
 
     def do_close(self):
         if self.flags == 'c' or self.flags == 'w':
-            if os.name == 'posix':
-                tempname = '%s.temp' % (self.file)
-                fh = open(tempname, 'wb')
-                pickle.dump(self.hash, fh)
-                fh.close()
-                os.rename(tempname, self.file)
-            else:
-                pickled = pickle.dumps(self.hash)
-                fh = open(self.file, 'wb')
-                fh.write(pickled)
-                fh.close()
+            pickled = pickle.dumps(self.hash)
+            util.safe_write(self.file, pickled)
 
         self.hash = {}
         self.flags = None

--- a/beaker/util.py
+++ b/beaker/util.py
@@ -492,3 +492,16 @@ def machine_identifier():
     else:
         machine_hash.update(socket.gethostname())
     return binascii.hexlify(machine_hash.digest()[0:3]).decode('ascii')
+
+
+def safe_write (filepath, contents):
+    if os.name == 'posix':
+        tempname = '%s.temp' % (filepath)
+        fh = open(tempname, 'wb')
+        fh.write(contents)
+        fh.close()
+        os.rename(tempname, filepath)
+    else:
+        fh = open(filepath, 'wb')
+        fh.write(contents)
+        fh.close()


### PR DESCRIPTION
This is a continuation of my efforts to deal with #134.

While buffering to a separate file and then moving it into location works for posix based systems, the lack of atomic move support on Windows and the fact that it will fail with an exception if the file already exists makes the solution not viable for that platform.

There are some complex ways that this can be dealt with, but they would have a negative performance hit (and I don't care enough about people who deploy to windows systems to devote the time to this).

Short of that, this PR reduces the time spent writing the file which in turn reduces the chances of corruption occurring. It does this by buffering the pickled output to a string rather than using the pickler's built in "write to file" system (which writes as the pickling happens).