### PR TITLE
Ability to pass expiretime into RedisNamespaceManager

### DIFF
--- a/beaker/ext/redisnm.py
+++ b/beaker/ext/redisnm.py
@@ -30,10 +30,10 @@ class RedisNamespaceManager(NamespaceManager):
 
     clients = SyncDict()
 
-    def __init__(self, namespace, url, expiretime=None, **kw):
+    def __init__(self, namespace, url, timeout=None, **kw):
         super(RedisNamespaceManager, self).__init__(namespace)
         self.lock_dir = None  # Redis uses redis itself for locking.
-        self.expiretime = expiretime
+        self.timeout = timeout
 
         if redis is None:
             raise RuntimeError('redis is not available')
@@ -69,8 +69,8 @@ class RedisNamespaceManager(NamespaceManager):
 
     def set_value(self, key, value, expiretime=None):
         value = pickle.dumps(value)
-        if expiretime is None and self.expiretime is not None:
-            expiretime = self.expiretime
+        if expiretime is None and self.timeout is not None:
+            expiretime = self.timeout
         if expiretime is not None:
             self.client.setex(self._format_key(key), int(expiretime), value)
         else:

--- a/beaker/ext/redisnm.py
+++ b/beaker/ext/redisnm.py
@@ -30,9 +30,10 @@ class RedisNamespaceManager(NamespaceManager):
 
     clients = SyncDict()
 
-    def __init__(self, namespace, url, **kw):
+    def __init__(self, namespace, url, expiretime=None, **kw):
         super(RedisNamespaceManager, self).__init__(namespace)
         self.lock_dir = None  # Redis uses redis itself for locking.
+        self.expiretime = expiretime
 
         if redis is None:
             raise RuntimeError('redis is not available')
@@ -66,10 +67,10 @@ class RedisNamespaceManager(NamespaceManager):
     def has_key(self, key):
         return key in self
 
-    def set_value(self, key, value, expiretime=None):
+    def set_value(self, key, value):
         value = pickle.dumps(value)
-        if expiretime is not None:
-            self.client.setex(self._format_key(key), int(expiretime), value)
+        if self.expiretime is not None:
+            self.client.setex(self._format_key(key), int(self.expiretime), value)
         else:
             self.client.set(self._format_key(key), value)
 

--- a/beaker/ext/redisnm.py
+++ b/beaker/ext/redisnm.py
@@ -67,10 +67,12 @@ class RedisNamespaceManager(NamespaceManager):
     def has_key(self, key):
         return key in self
 
-    def set_value(self, key, value):
+    def set_value(self, key, value, expiretime=None):
         value = pickle.dumps(value)
-        if self.expiretime is not None:
-            self.client.setex(self._format_key(key), int(self.expiretime), value)
+        if expiretime is None and self.expiretime is not None:
+            expiretime = self.expiretime
+        if expiretime is not None:
+            self.client.setex(self._format_key(key), int(expiretime), value)
         else:
             self.client.set(self._format_key(key), value)
 

--- a/beaker/session.py
+++ b/beaker/session.py
@@ -150,7 +150,7 @@ class Session(dict):
         self.namespace_args = namespace_args
         # We want to pass timeout param to redis backend to support expiration of keys
         # In future, I believe, we can use this param for memcached and mongo as well
-        if self.type == 'ext:redis':
+        if self.timeout is not None and self.type == 'ext:redis':
             # The backend expiration should always be a bit longer (I decied to use 2 minutes) than the
             # session expiration itself to prevent the case where the backend data expires while
             # the session is being read (PR#153)

--- a/beaker/session.py
+++ b/beaker/session.py
@@ -150,7 +150,7 @@ class Session(dict):
         self.namespace_args = namespace_args
         # We want to pass timeout param to redis backend to support expiration of keys
         # In future, I believe, we can use this param for memcached and mongo as well
-        if self.timeout is not None and self.type == 'ext:redis':
+        if timeout is not None and self.type == 'ext:redis':
             # The backend expiration should always be a bit longer (I decied to use 2 minutes) than the
             # session expiration itself to prevent the case where the backend data expires while
             # the session is being read (PR#153)

--- a/beaker/session.py
+++ b/beaker/session.py
@@ -148,6 +148,13 @@ class Session(dict):
         self.namespace_class = namespace_class or clsmap[self.type]
 
         self.namespace_args = namespace_args
+        # We want to pass timeout param to redis backend to support expiration of keys
+        # In future, I believe, we can use this param for memcached and mongo as well
+        if self.type == 'ext:redis':
+            # The backend expiration should always be a bit longer (I decied to use 2 minutes) than the
+            # session expiration itself to prevent the case where the backend data expires while
+            # the session is being read (PR#153)
+            self.namespace_args['timeout'] = timeout + 60 * 2
 
         self.request = request
         self.data_dir = data_dir

--- a/beaker/session.py
+++ b/beaker/session.py
@@ -148,13 +148,6 @@ class Session(dict):
         self.namespace_class = namespace_class or clsmap[self.type]
 
         self.namespace_args = namespace_args
-        # We want to pass timeout param to redis backend to support expiration of keys
-        # In future, I believe, we can use this param for memcached and mongo as well
-        if timeout is not None and self.type == 'ext:redis':
-            # The backend expiration should always be a bit longer (I decied to use 2 minutes) than the
-            # session expiration itself to prevent the case where the backend data expires while
-            # the session is being read (PR#153)
-            self.namespace_args['timeout'] = timeout + 60 * 2
 
         self.request = request
         self.data_dir = data_dir
@@ -163,6 +156,14 @@ class Session(dict):
         if timeout and not save_accessed_time:
             raise BeakerException("timeout requires save_accessed_time")
         self.timeout = timeout
+        # We want to pass timeout param to redis backend to support expiration of keys
+        # In future, I believe, we can use this param for memcached and mongo as well
+        if self.timeout is not None and self.type == 'ext:redis':
+            # The backend expiration should always be a bit longer (I decied to use 2 minutes) than the
+            # session expiration itself to prevent the case where the backend data expires while
+            # the session is being read (PR#153)
+            self.namespace_args['timeout'] = self.timeout + 60 * 2
+
         self.save_atime = save_accessed_time
         self.use_cookies = use_cookies
         self.cookie_expires = cookie_expires


### PR DESCRIPTION
Hey,

I was trying to figure out what is the best way to clean up old / unused session data from Redis backend. I found that the basic mechanics for setting expiration time is there, but there's no way to use it from layers above. With that change, I'm able to just pass `expiretime` into Middleware, and voila - keys in reds are having expiration time set! :)

Example usage of middleware:
```
app = SessionMiddleware(app, config, expiretime=5000)
```

Would be great if you could merge this change.

Thanks!

Kacper.
