### PR TITLE
Fall back to configured path when using CookieSession.

### DIFF
--- a/beaker/session.py
+++ b/beaker/session.py
@@ -574,7 +574,7 @@ class CookieSession(Session):
         self.secure = secure
         self.httponly = httponly
         self._domain = cookie_domain
-        self._path = cookie_path
+        self['_path'] = self._path = cookie_path
         self.invalidate_corrupt = invalidate_corrupt
         self._set_serializer(data_serializer)
 


### PR DESCRIPTION
I noticed when using `CookieSession`, I wasn't able to set the cookie path no matter how I configured `SessionMiddleware`.

It turns out that it is only using `_path` in the session dict and this is never initialized. So it will always fall back to '/' instead.