### PR TITLE
Redis lock should have a expire time

### DIFF
--- a/beaker/ext/redisnm.py
+++ b/beaker/ext/redisnm.py
@@ -134,7 +134,7 @@ class RedisSynchronizer(SynchronizerImpl):
     def do_acquire_write_lock(self, wait):
         owner_id = self._get_owner_id()
         while True:
-            if self.client.setnx(self.identifier, owner_id):
+            if self.client.set(self.identifier, owner_id, ex=self.LOCK_EXPIRATION, nx=True):
                 self.client.pexpire(self.identifier, self.LOCK_EXPIRATION * 1000)
                 return True
 


### PR DESCRIPTION
In my production environment, I found that if the lock of redis was not set expired, when my program is restart before release the lock, the lock will not expired forever.