### PR TITLE
Fix: A true way to set redis expire time

### DIFF
--- a/beaker/ext/redisnm.py
+++ b/beaker/ext/redisnm.py
@@ -134,7 +134,7 @@ class RedisSynchronizer(SynchronizerImpl):
     def do_acquire_write_lock(self, wait):
         owner_id = self._get_owner_id()
         while True:
-            if self.client.setnx(self.identifier, owner_id):
+            if self.client.set(self.identifier, owner_id, ex=self.LOCK_EXPIRATION, nx=True):
                 self.client.pexpire(self.identifier, self.LOCK_EXPIRATION * 1000)
                 return True
 

--- a/beaker/ext/redisnm.py
+++ b/beaker/ext/redisnm.py
@@ -135,7 +135,6 @@ class RedisSynchronizer(SynchronizerImpl):
         owner_id = self._get_owner_id()
         while True:
             if self.client.set(self.identifier, owner_id, ex=self.LOCK_EXPIRATION, nx=True):
-                self.client.pexpire(self.identifier, self.LOCK_EXPIRATION * 1000)
                 return True
 
             if not wait:


### PR DESCRIPTION
Set value and expire flag is atomic now.
Otherwise in my system, when a lock value is set, but my system restart before the lock value is given the expire time, the lock will be a deadlock.