### PR TITLE
Set samesite cookie attribute on cookie creation

### DIFF
--- a/beaker/session.py
+++ b/beaker/session.py
@@ -714,6 +714,8 @@ class CookieSession(Session):
             self.cookie[self.key]['domain'] = self._domain
         if self.secure:
             self.cookie[self.key]['secure'] = True
+        if self.samesite:
+            self.cookie[self.key]['samesite'] = self.samesite
         self._set_cookie_http_only()
 
         self.cookie[self.key]['path'] = self.get('_path', '/')

--- a/tests/test_cookie_only.py
+++ b/tests/test_cookie_only.py
@@ -302,6 +302,19 @@ def test_cookie_properly_expires():
     assert 'The current value is: 1' in res, res
 
 
+def test_cookie_attributes_are_preserved():
+    options = {'session.type': 'cookie',
+               'session.validate_key': 'hoobermas',
+               'session.httponly': True,
+               'session.secure': True,
+               'session.samesite': 'Strict'}
+    app = TestApp(SessionMiddleware(simple_app, options))
+    res = app.get('/')
+    cookie = res.headers['Set-Cookie']
+    assert 'secure' in cookie.lower()
+    assert 'httponly' in cookie.lower()
+    assert 'samesite=strict' in cookie.lower()
+
 if __name__ == '__main__':
     from paste import httpserver
     wsgi_app = SessionMiddleware(simple_app, {})


### PR DESCRIPTION
#159 adds support for the SameSite flag in cookie sessions, but does not set this option when the cookie is created. As a result, the `session.samesite` option does not actually set the SameSite flag in many cases. This resolves the above issue.