### PR TITLE
Include tests in source distribution for PyPI

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include tests *.py


### PR DESCRIPTION
Hi, in OpenBSD we rely on regression tests for porting as well as to check for breakage when updating dependencies. Including them in the PyPI tarball would be very helpful for our porters.