### PR TITLE
Remove ID generation fallback for when the uuid module is not found

### DIFF
--- a/beaker/session.py
+++ b/beaker/session.py
@@ -8,6 +8,7 @@ from beaker import crypto, util
 from beaker.cache import clsmap
 from beaker.exceptions import BeakerException, InvalidCryptoBackendError
 from beaker.cookie import SimpleCookie
+import uuid
 
 
 months = (None, "Jan", "Feb", "Mar", "Apr", "May", "Jun",
@@ -30,34 +31,8 @@ class _InvalidSignatureType(object):
 InvalidSignature = _InvalidSignatureType()
 
 
-try:
-    import uuid
-
-    def _session_id():
-        return uuid.uuid4().hex
-except ImportError:
-    import random
-    if hasattr(os, 'getpid'):
-        getpid = os.getpid
-    else:
-        def getpid():
-            return ''
-
-    def _session_id():
-        id_str = "%f%s%f%s" % (
-                    time.time(),
-                    id({}),
-                    random.random(),
-                    getpid()
-                )
-        # NB: nothing against second parameter to b64encode, but it seems
-        #     to be slower than simple chained replacement
-        if not PY2:
-            raw_id = b64encode(sha1(id_str.encode('ascii')).digest())
-            return str(raw_id.replace(b'+', b'-').replace(b'/', b'_').rstrip(b'='))
-        else:
-            raw_id = b64encode(sha1(id_str).digest())
-            return raw_id.replace('+', '-').replace('/', '_').rstrip('=')
+def _session_id():
+    return uuid.uuid4().hex
 
 
 class SignedCookie(SimpleCookie):


### PR DESCRIPTION
Session ID generation preferentially uses the [uuid module](https://docs.python.org/2.7/library/uuid.html), which was added in Python 2.5.

![image](https://user-images.githubusercontent.com/933552/69685264-ac38b300-1070-11ea-8709-52be1e8ade89.png)

Beaker has a fallback — implemented in 2011 — that uses a different approach when `import uuid` fails. Support for Python 2.4 and 2.5 was dropped in 2015, so all versions of Python currently supported by Beaker have the uuid module. This PR removes the now-unnecessary fallback.