### PR TITLE
Fixed issue #122 - Session ignores deserializer json

### DIFF
--- a/beaker/session.py
+++ b/beaker/session.py
@@ -94,7 +94,7 @@ class SignedCookie(SimpleCookie):
 
 class _ConfigurableSession(dict):
     """Provides support for configurable Session objects.
-
+    
     Provides a way to ensure some properties of sessions
     are always available with pre-configured values
     when they are not available in the session cookie itself.
@@ -171,7 +171,7 @@ class Session(_ConfigurableSession):
             cookie_path=cookie_path
         )
         self.clear()
-
+        
         if not type:
             if data_dir:
                 self.type = 'file'
@@ -293,7 +293,7 @@ class Session(_ConfigurableSession):
         r = time.strftime("%%s, %d-%%s-%Y %H:%M:%S GMT", v)
         return r % (weekdays[v[6]], months[v[1]])
 
-
+        
     def _set_cookie_expires(self, expires):
         if expires is None:
             expires = self.cookie_expires
@@ -379,10 +379,7 @@ class Session(_ConfigurableSession):
             return nonce + b64encode(self.crypto_module.aesEncrypt(data, encrypt_key))
         else:
             data = self.serializer.dumps(session_data)
-            if isinstance(self, CookieSession):
-                return b64encode(data)
-            else:
-                return data
+            return b64encode(data)
 
     def _decrypt_data(self, session_data):
         """Base64, decipher, then un-serialize the data for the session
@@ -397,9 +394,7 @@ class Session(_ConfigurableSession):
             payload = b64decode(session_data[nonce_b64len:])
             data = self.crypto_module.aesDecrypt(payload, encrypt_key)
         else:
-            data = session_data
-            if isinstance(self, CookieSession):
-                data = b64decode(session_data)
+            data = b64decode(session_data)
 
         return self.serializer.loads(data)
 

--- a/beaker/session.py
+++ b/beaker/session.py
@@ -94,7 +94,7 @@ class SignedCookie(SimpleCookie):
 
 class _ConfigurableSession(dict):
     """Provides support for configurable Session objects.
-    
+
     Provides a way to ensure some properties of sessions
     are always available with pre-configured values
     when they are not available in the session cookie itself.
@@ -171,7 +171,7 @@ class Session(_ConfigurableSession):
             cookie_path=cookie_path
         )
         self.clear()
-        
+
         if not type:
             if data_dir:
                 self.type = 'file'
@@ -293,7 +293,7 @@ class Session(_ConfigurableSession):
         r = time.strftime("%%s, %d-%%s-%Y %H:%M:%S GMT", v)
         return r % (weekdays[v[6]], months[v[1]])
 
-        
+
     def _set_cookie_expires(self, expires):
         if expires is None:
             expires = self.cookie_expires
@@ -378,8 +378,7 @@ class Session(_ConfigurableSession):
             data = self.serializer.dumps(session_data)
             return nonce + b64encode(self.crypto_module.aesEncrypt(data, encrypt_key))
         else:
-            data = self.serializer.dumps(session_data)
-            return b64encode(data)
+            return self.serializer.dumps(session_data)
 
     def _decrypt_data(self, session_data):
         """Base64, decipher, then un-serialize the data for the session
@@ -394,7 +393,7 @@ class Session(_ConfigurableSession):
             payload = b64decode(session_data[nonce_b64len:])
             data = self.crypto_module.aesDecrypt(payload, encrypt_key)
         else:
-            data = b64decode(session_data)
+            data = session_data
 
         return self.serializer.loads(data)
 

--- a/beaker/session.py
+++ b/beaker/session.py
@@ -378,7 +378,11 @@ class Session(_ConfigurableSession):
             data = self.serializer.dumps(session_data)
             return nonce + b64encode(self.crypto_module.aesEncrypt(data, encrypt_key))
         else:
-            return self.serializer.dumps(session_data)
+            data = self.serializer.dumps(session_data)
+            if self.__class__ == CookieSession:
+                return b64encode(data)
+            else:
+                return data
 
     def _decrypt_data(self, session_data):
         """Base64, decipher, then un-serialize the data for the session
@@ -394,6 +398,8 @@ class Session(_ConfigurableSession):
             data = self.crypto_module.aesDecrypt(payload, encrypt_key)
         else:
             data = session_data
+            if self.__class__ == CookieSession:
+                data = b64decode(session_data)
 
         return self.serializer.loads(data)
 

--- a/beaker/session.py
+++ b/beaker/session.py
@@ -436,7 +436,7 @@ class Session(_ConfigurableSession):
             try:
                 session_data = self.namespace['session']
 
-                if (session_data is not None and self.encrypt_key):
+                if session_data is not None:
                     session_data = self._decrypt_data(session_data)
 
                 # Memcached always returns a key, its None when its not
@@ -511,8 +511,7 @@ class Session(_ConfigurableSession):
             else:
                 data = dict(self.items())
 
-            if self.encrypt_key:
-                data = self._encrypt_data(data)
+            data = self._encrypt_data(data)
 
             # Save the data
             if not data and 'session' in self.namespace:

--- a/beaker/session.py
+++ b/beaker/session.py
@@ -379,7 +379,7 @@ class Session(_ConfigurableSession):
             return nonce + b64encode(self.crypto_module.aesEncrypt(data, encrypt_key))
         else:
             data = self.serializer.dumps(session_data)
-            if self.__class__ == CookieSession:
+            if isinstance(self, CookieSession):
                 return b64encode(data)
             else:
                 return data
@@ -398,7 +398,7 @@ class Session(_ConfigurableSession):
             data = self.crypto_module.aesDecrypt(payload, encrypt_key)
         else:
             data = session_data
-            if self.__class__ == CookieSession:
+            if isinstance(self, CookieSession):
                 data = b64decode(session_data)
 
         return self.serializer.loads(data)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -399,7 +399,7 @@ def test_use_json_serializer_without_encryption_key():
     assert 'foo' in session
     serialized_session = open(session.namespace.file, 'rb').read()
     memory_state = pickle.loads(serialized_session)
-    session_data = b64decode(memory_state.get('session'))
+    session_data = memory_state.get('session')
     data = deserialize(session_data, 'json')
     assert 'foo' in data
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from beaker._compat import u_, pickle
+from beaker._compat import u_, pickle, b64decode
 
 import binascii
 import shutil
@@ -14,7 +14,7 @@ from beaker.container import MemoryNamespaceManager
 from beaker.crypto import get_crypto_module
 from beaker.exceptions import BeakerException
 from beaker.session import CookieSession, Session, SessionObject
-from beaker.util import assert_raises
+from beaker.util import assert_raises, deserialize
 
 
 def get_session(**kwargs):

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -399,7 +399,7 @@ def test_use_json_serializer_without_encryption_key():
     assert 'foo' in session
     serialized_session = open(session.namespace.file, 'rb').read()
     memory_state = pickle.loads(serialized_session)
-    session_data = memory_state.get('session')
+    session_data = b64decode(memory_state.get('session'))
     data = deserialize(session_data, 'json')
     assert 'foo' in data
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -397,7 +397,7 @@ def test_use_json_serializer_without_encryption_key():
     so.save()
     session = get_session(id=so.id, use_cookies=False, type='file', data_dir='./cache', data_serializer='json')
     assert 'foo' in session
-    serialized_session = open(session.namespace.file, 'r').read()
+    serialized_session = open(session.namespace.file, 'rb').read()
     memory_state = pickle.loads(serialized_session)
     session_data = b64decode(memory_state.get('session'))
     data = deserialize(session_data, 'json')

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -390,6 +390,19 @@ def test_file_based_replace_optimization():
     assert 'test' not in session.namespace
     session.namespace.do_close()
 
+@with_setup(setup_cookie_request)
+def test_use_json_serializer_without_encryption_key():
+    so = get_session(use_cookies=False, type='file', data_dir='./cache', data_serializer='json')
+    so['foo'] = 'bar'
+    so.save()
+    session = get_session(id=so.id, use_cookies=False, type='file', data_dir='./cache', data_serializer='json')
+    assert 'foo' in session
+    serialized_session = open(session.namespace.file, 'r').read()
+    memory_state = pickle.loads(serialized_session)
+    session_data = b64decode(memory_state.get('session'))
+    data = deserialize(session_data, 'json')
+    assert 'foo' in data
+
 
 @with_setup(setup_cookie_request)
 def test_invalidate_corrupt():


### PR DESCRIPTION
Unittest using the file namespace manager also provided. I haven't run tests for mongodb and all combinations of other drivers so I'm assuming they will run based on the fact that it's a base64 encoded string and everyone should be able to insert a string.
This commit will likely invalidate all sessions once deployed due to the fact that all sessions now get base64 encoded when written in storage (and decoded back) vs the previous situation of only encrypted sessions getting base64 encoded.