### PR TITLE
Use `beaker.readthedocs.io` in `README.rst`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ Documentation
 =============
 
 Documentation can be found on the `Official Beaker Docs site
-<http://beaker.groovie.org/>`_.
+<https://beaker.readthedocs.org/>`_.
 
 
 Source


### PR DESCRIPTION
The URL was updated in the GitHub repo description as of #89 and in the `setup.py` in #104 but has not been updated in the README yet, which is published to PyPI as the package description and displayed (obviously) on GitHub. 🧹