### PR TITLE
Fix issue #180 - KeyError when loading deleted session

### DIFF
--- a/beaker/session.py
+++ b/beaker/session.py
@@ -437,6 +437,7 @@ class Session(_ConfigurableSession):
                 self.is_new = True
 
             if self.timeout is not None and \
+               '_accessed_time' in session_data and \
                now - session_data['_accessed_time'] > self.timeout:
                 timed_out = True
             else:

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -483,6 +483,16 @@ def test_invalidate_invalid_signed_cookie_invalidate_corrupt():
     assert "foo" not in dict(session)
 
 
+def test_load_deleted_from_storage_session__not_loaded():
+    req = {'cookie': {'beaker.session.id': 123}}
+    session = Session(req, timeout=1)
+
+    session.delete()
+    session.save()
+
+    Session(req, timeout=1)
+
+
 class TestSaveAccessedTime(unittest.TestCase):
     # These tests can't use the memory session type since it seems that loading
     # winds up with references to the underlying storage and makes changes to


### PR DESCRIPTION
Session.load does not properly handle state after .delete and .save was called.

This happens when user logs out, but saves session id, and then tries to use it again.