### PR TITLE
Ignore the .eggs directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ jyenv/
 pypyenv/
 env*/
 tests/test.db
+/.eggs/


### PR DESCRIPTION
It is generated by setuptools in certain situations.