### PR TITLE
allow ignoring some arguments for caching key

### DIFF
--- a/beaker/cache.py
+++ b/beaker/cache.py
@@ -130,7 +130,7 @@ clsmap = _backends({
 })
 
 
-def cache_region(region, *args):
+def cache_region(region, *args, ignore_args=None):
     """Decorate a function such that its return result is cached,
     using a "region" to indicate the cache arguments.
 
@@ -198,7 +198,7 @@ def cache_region(region, *args):
         not included in the "key" used for caching.   New in 1.6.
 
     """
-    return _cache_decorate(args, None, None, region)
+    return _cache_decorate(args, None, None, region, ignore_args=ignore_args)
 
 
 def region_invalidate(namespace, region, *args):
@@ -542,10 +542,11 @@ class CacheManager(object):
         _cache_decorator_invalidate(cache, key_length, args)
 
 
-def _cache_decorate(deco_args, manager, options, region):
+def _cache_decorate(deco_args, manager, options, region, ignore_args=None):
     """Return a caching function decorator."""
 
     cache = [None]
+    ignore_args = [ignore_args]
 
     def decorate(func):
         namespace = util.func_namespace(func)
@@ -579,6 +580,14 @@ def _cache_decorate(deco_args, manager, options, region):
             cache_key_args = args
             if skip_self:
                 cache_key_args = args[1:]
+            if ignore_args and ignore_args[0]:
+                cache_key_args_include = []
+                arg_names = list(signature.parameters)
+                arg_names = arg_names[1:] if skip_self else arg_names
+                for name, value in zip(arg_names, cache_key_args):
+                    if name not in ignore_args[0]:
+                        cache_key_args_include.append(value)
+                cache_key_args = cache_key_args_include
 
             cache_key = u_(" ").join(map(u_, chain(deco_args, cache_key_args, cache_key_kwargs)))
 


### PR DESCRIPTION
This PR is not as complete as extensive as #202, but provides minimal implementation that fulfills the use case I'm facing. 
It partially addresses #201. 

This allows to decorate a function with some parameters to be ignored when creating the cache key that will match following calls. 
It allows to group together some operations where a parameter is important for the calculation of the function, but is not strictly required to map the call to the cached result. This is particularly useful in situation where the parameter cannot be cached (not serializable).
