### PR TITLE
docs: Fix a few typos

### DIFF
--- a/beaker/crypto/nsscrypto.py
+++ b/beaker/crypto/nsscrypto.py
@@ -3,7 +3,7 @@ import nss.nss
 
 nss.nss.nss_init_nodb()
 
-# Apparently the rest of beaker doesn't care about the particluar cipher,
+# Apparently the rest of beaker doesn't care about the particular cipher,
 # mode and padding used.
 # NOTE: A constant IV!!! This is only secure if the KEY is never reused!!!
 _mech = nss.nss.CKM_AES_CBC_PAD

--- a/beaker/middleware.py
+++ b/beaker/middleware.py
@@ -31,7 +31,7 @@ class CacheMiddleware(object):
             setups that accumulate multiple component settings in a
             single dictionary. If config contains *no cache. prefixed
             args*, then *all* of the config options will be used to
-            intialize the Cache objects.
+            initialize the Cache objects.
 
         ``environ_key``
             Location where the Cache instance will keyed in the WSGI
@@ -91,7 +91,7 @@ class SessionMiddleware(object):
             setups that accumulate multiple component settings in a
             single dictionary. If config contains *no session. prefixed
             args*, then *all* of the config options will be used to
-            intialize the Session objects.
+            initialize the Session objects.
 
         ``environ_key``
             Location where the Session instance will keyed in the WSGI


### PR DESCRIPTION
There are small typos in:
- beaker/crypto/nsscrypto.py
- beaker/middleware.py

Fixes:
- Should read `initialize` rather than `intialize`.
- Should read `particular` rather than `particluar`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md