### PR TITLE
fix #226 and optimize session data storage logic

### DIFF
--- a/beaker/container.py
+++ b/beaker/container.py
@@ -63,6 +63,7 @@ class NamespaceManager(object):
     def __init__(self, namespace):
         self._init_dependencies()
         self.namespace = namespace
+        self.has_serialized_value = False
 
     def get_creation_lock(self, key):
         """Return a locking object that is used to synchronize
@@ -594,7 +595,7 @@ class DBMNamespaceManager(OpenResourceNamespaceManager):
             os.remove(f)
 
     def __getitem__(self, key):
-        return pickle.loads(self.dbm[key])
+        return self.dbm[key] if self.has_serialized_value else pickle.loads(self.dbm[key])
 
     def __contains__(self, key):
         if PYVER == (3, 2):
@@ -605,7 +606,9 @@ class DBMNamespaceManager(OpenResourceNamespaceManager):
         return key in self.dbm
 
     def __setitem__(self, key, value):
-        self.dbm[key] = pickle.dumps(value)
+        if not self.has_serialized_value:
+            value = pickle.dumps(value)
+        self.dbm[key] = value
 
     def __delitem__(self, key):
         del self.dbm[key]

--- a/beaker/ext/redisnm.py
+++ b/beaker/ext/redisnm.py
@@ -59,7 +59,7 @@ class RedisNamespaceManager(NamespaceManager):
         entry = self.client.get(self._format_key(key))
         if entry is None:
             raise KeyError(key)
-        return pickle.loads(entry)
+        return entry if self.has_serialized_value else pickle.loads(entry)
 
     def __contains__(self, key):
         return self.client.exists(self._format_key(key))
@@ -68,7 +68,8 @@ class RedisNamespaceManager(NamespaceManager):
         return key in self
 
     def set_value(self, key, value, expiretime=None):
-        value = pickle.dumps(value)
+        if not self.has_serialized_value:
+            value = pickle.dumps(value)
         if expiretime is None and self.timeout is not None:
             expiretime = self.timeout
         if expiretime is not None:

--- a/beaker/session.py
+++ b/beaker/session.py
@@ -357,7 +357,7 @@ class Session(_ConfigurableSession):
             data = self.serializer.dumps(session_data)
             return b64encode(data)
         else:
-            return session_data
+            return self.serializer.dumps(session_data)
 
     def _deserialize_data(self, session_data):
         """Base64, decipher, then un-serialize the data for the session
@@ -376,7 +376,7 @@ class Session(_ConfigurableSession):
             data = b64decode(session_data)
             return self.serializer.loads(data)
         else:
-            return session_data
+            return self.serializer.loads(session_data)
 
     def _delete_cookie(self):
         self.request['set_cookie'] = True
@@ -405,6 +405,7 @@ class Session(_ConfigurableSession):
             data_dir=self.data_dir,
             digest_filenames=False,
             **self.namespace_args)
+        self.namespace.has_serialized_value = True
         now = time.time()
         if self.use_cookies:
             self.request['set_cookie'] = True
@@ -485,6 +486,7 @@ class Session(_ConfigurableSession):
                                     digest_filenames=False,
                                     **self.namespace_args)
 
+        self.namespace.has_serialized_value = True
         self.namespace.acquire_write_lock(replace=True)
         try:
             if accessed_only:

--- a/beaker/util.py
+++ b/beaker/util.py
@@ -458,7 +458,7 @@ class PickleSerializer(object):
         return pickle.loads(data_string)
 
     def dumps(self, data):
-        return pickle.dumps(data, 2)
+        return pickle.dumps(data, 2) if PY2 else pickle.dumps(data)
 
 
 class JsonSerializer(object):

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -390,6 +390,7 @@ def test_file_based_replace_optimization():
     assert 'test' not in session.namespace
     session.namespace.do_close()
 
+
 def test_use_json_serializer_without_encryption_key():
     setup_cookie_request()
     so = get_session(use_cookies=False, type='file', data_dir='./cache', data_serializer='json')
@@ -401,6 +402,21 @@ def test_use_json_serializer_without_encryption_key():
     memory_state = pickle.loads(serialized_session)
     session_data = memory_state.get('session')
     data = deserialize(session_data, 'json')
+    assert 'foo' in data
+
+
+def test_use_pickle_serializer_without_encryption_key():
+    setup_cookie_request()
+    so = get_session(use_cookies=False, type='file', data_dir='./cache', data_serializer='pickle')
+    so['foo'] = 'bar'
+    so.save()
+    # default data_serializer will pickle
+    session = get_session(id=so.id, use_cookies=False, type='file', data_dir='./cache')
+    assert 'foo' in session
+    serialized_session = open(session.namespace.file, 'rb').read()
+    memory_state = pickle.loads(serialized_session)
+    session_data = memory_state.get('session')
+    data = deserialize(session_data, 'pickle')
     assert 'foo' in data
 
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from beaker._compat import u_, pickle, b64decode
+from beaker._compat import u_, pickle
 
 import binascii
 import shutil
@@ -399,7 +399,7 @@ def test_use_json_serializer_without_encryption_key():
     assert 'foo' in session
     serialized_session = open(session.namespace.file, 'rb').read()
     memory_state = pickle.loads(serialized_session)
-    session_data = b64decode(memory_state.get('session'))
+    session_data = memory_state.get('session')
     data = deserialize(session_data, 'json')
     assert 'foo' in data
 


### PR DESCRIPTION
PR #186 make serialized format changed before 1.11, the stored data serialize multiple times. This PR restore session serialized format without base64. The session data always serialize by `Session.serializer` , so I added flag for avoid session data pickling twice. Only redis, mongo and dbm backends apply that logic, others backends keeping original logic.