### PR TITLE
Make md5 calls succeed on systems enforcing FIPS compliance.

### DIFF
--- a/beaker/util.py
+++ b/beaker/util.py
@@ -486,7 +486,14 @@ def deserialize(data_string, method):
 
 
 def machine_identifier():
-    machine_hash = hashlib.md5()
+    try:
+        machine_hash = hashlib.md5(usedforsecurity=False)
+    except TypeError:
+        # Fall back to earlier version that did not support the 
+        # usedforsecurity parameter. This fallback will not work on
+        # systems configured to enforce Federal Information Processing
+        # Standard (FIPS) compliance.
+        machine_hash = hashlib.md5()
     if not PY2:
         machine_hash.update(socket.gethostname().encode())
     else:


### PR DESCRIPTION
The Federal Information Processing Standards (FIPS) do not allow using the md5 algorithm for encryption since it is considered too weak. The hashlib implementation of md5 provided a workaround permitting continued use of the fast md5 algorithm by explicitly noting the use was not for security purposes. The changes here try using that workaround, and fall back to failing on systems enforcing FIPS.