### PR TITLE
Specify packages using include rather than exclude

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ zip-safe = false
 platforms = ["any"]
 
 [tool.setuptools.packages.find]
-exclude = ["ez_setup*", "examples*", "tests*", "tests.*", "beaker.docs"]
+include = ["beaker", "beaker.crypto", "beaker.ext"]
 
 [tool.pytest.ini_options]
 addopts = "-v"


### PR DESCRIPTION
This avoids possible duplication if a wheel is built more than once from the same directory.

I ran into this when upgrading Debian's packaging of beaker; we're currently in a transitional period where we're building for both Python 3.13 and 3.14, and this resulted in the second of the two wheels having a stray `build` directory.  Using `include` rather than `exclude` avoids this, and seems to be simpler anyway.